### PR TITLE
Revert "build: look for meson.py, as distributed by arch"

### DIFF
--- a/configure
+++ b/configure
@@ -2,7 +2,7 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-which meson.py > /dev/null 2>&1
+which meson > /dev/null 2>&1
 if [ $? != 0 ]
 then
     echo "You should install mesonbuild to build gst-plugins-vr: http://mesonbuild.com/"
@@ -13,7 +13,7 @@ then
 fi
 
 rm -Rf build > /dev/null 2>&1
-mkdir build/ && cd build && CFLAGS='-fdiagnostics-color=always' meson.py ../ $@
+mkdir build/ && cd build && CFLAGS='-fdiagnostics-color=always' meson ../ $@
 
 cat <<EOF > $DIR/Makefile
 all:


### PR DESCRIPTION
This reverts commit 62e5d2cd17ce2fc77afd9e119762a92be7315b4d.

Since meson 0.33.0 the archlinux package removes the .py extension:
https://git.archlinux.org/svntogit/community.git/commit/trunk?h=packages/meson&id=59eeeaacd3631ff065f1f1e6f9ecb7200719b673
