### PR TITLE
install into appropriate site_packages

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -158,4 +158,5 @@ executable('mesh', 'tests/3d/mesh.c', 'gpu/shaders.c',
 
 # install sphvr
 install_data('sphvr/sphvr', install_dir : 'bin/')
-install_subdir('sphvr', install_dir : 'lib/sphvr/python')
+site_packages_dir = run_command('./print_sitepackages_dir.py').stdout().strip()
+install_subdir('sphvr', install_dir : site_packages_dir)

--- a/print_sitepackages_dir.py
+++ b/print_sitepackages_dir.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+import site
+print(site.getsitepackages()[0])


### PR DESCRIPTION
I never used meson, so I googled a bit and didn't find a way to properly install python modules.

So a script that will be run with the same python interpreter as sphvr printing its first site_package dir seemed like the next best thing.
