### PR TITLE
sphvr: Support running on wayland

### DIFF
--- a/sphvr/sinks.py
+++ b/sphvr/sinks.py
@@ -11,11 +11,8 @@ class GLSink:
         self.widget = Gtk.DrawingArea()
         self.widget.set_double_buffered(True)
 
-    def xid(self):
-        return self.widget.get_window().get_xid()
-
     def set_handle(self):
-        self.element.set_window_handle(self.xid())
+        pass
 
 
 class GtkGLSink:

--- a/sphvr/sphvr
+++ b/sphvr/sphvr
@@ -16,13 +16,6 @@ from gi.repository import Gdk, Gst, Gtk, GdkX11, GstVideo, GstGL, GnomeDesktop, 
 from sphvr.sinks import *
 from collections import OrderedDict
 
-from ctypes import cdll
-try:
-    x11 = cdll.LoadLibrary('libX11.so')
-    x11.XInitThreads()
-except OSError:
-    pass
-
 
 # Check if we're in development or installed version and set paths properly
 def _in_devel():


### PR DESCRIPTION
for wayland environments sphvr is not usable.

Detect environment could be a better option